### PR TITLE
Change banner logic and add architecture choice in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ GOTEST=$(GOCMD) test -v
 GOBUILD=$(GOCMD) build
 BINARY_NAME=dumproid
 DEVICES:=$(shell adb devices | grep -c 'device$$')
+# Choose the architecture for your device
+ARCH=arm
+#ARCH=arm64
 
 all: build deploy
 
@@ -10,7 +13,7 @@ test:
 	$(GOTEST) ./pkg/*
 
 build:
-	GOOS=linux GOARCH=arm64 GOARM=7 $(GOBUILD) -o $(BINARY_NAME)
+	GOOS=linux GOARCH=$(ARCH) GOARM=7 $(GOBUILD) -o $(BINARY_NAME)
 
 clean:
 	rm $(BINARY_NAME)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,7 +19,7 @@ var (
 	size        int64
 	hexdump     bool
 	memorymap   bool
-	quiet       bool
+	banner      bool
 	pid         string
 	permission  string
 	outputPath  string
@@ -29,7 +29,7 @@ var rootCmd = &cobra.Command{
 	Use:   "dumproid",
 	Short: "Android memory dump tool without ndk",
 	Run: func(cmd *cobra.Command, args []string) {
-		if !quiet {
+		if banner {
 			asciiArt()
 		}
 
@@ -63,7 +63,7 @@ func init() {
 	rootCmd.Flags().Int64VarP(&size, "number", "n", 0x100, "number of bytes")
 	rootCmd.Flags().BoolVarP(&memorymap, "maps", "m", false, "output memory mapping")
 	rootCmd.Flags().BoolVarP(&hexdump, "dump", "d", false, "output hexdump memory")
-	rootCmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "Do not print messages")
+	rootCmd.Flags().BoolVarP(&banner, "banner", "b", false, "print banner")
 	rootCmd.Flags().StringVarP(&outputPath, "output", "o", "/data/local/tmp", "output path")
 	rootCmd.Flags().StringVarP(&permission, "filter", "f", "", "")
 	rootCmd.Flags().StringVarP(&pid, "pid", "p", "", "target app's pid")


### PR DESCRIPTION
A couple of quick changes - one to swap the banner logic over; as banners spawning *everytime* are just evil and wasteful.

The other is to make a quick change to Makefile so it is easier to swap the architecture to arm instead of arm64.